### PR TITLE
fix(x/feegrant): remove expiration queue entry at revoke

### DIFF
--- a/x/feegrant/keeper/keeper.go
+++ b/x/feegrant/keeper/keeper.go
@@ -174,7 +174,7 @@ func (k Keeper) revokeAllowance(ctx context.Context, granter, grantee sdk.AccAdd
 	}
 
 	if exp != nil {
-		if err := store.Delete(feegrant.FeeAllowancePrefixQueue(exp, feegrant.FeeAllowanceKey(grantee, granter)[1:])); err != nil {
+		if err := store.Delete(feegrant.FeeAllowancePrefixQueue(exp, key[1:])); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
## Description

Apply [fix](https://github.com/cosmos/cosmos-sdk/pull/25540)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed fee grant allowance revocation to correctly remove associated expiry entries, ensuring proper cleanup of revoked allowances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->